### PR TITLE
Spec skill fix

### DIFF
--- a/scripts/items/sheet/item-sheet.js
+++ b/scripts/items/sheet/item-sheet.js
@@ -133,7 +133,7 @@ export class cncItemSheet extends ItemSheet {
             }
 
             itemObj.statRank = statRank;
-            itemObj.total = statRank + specRank + skillRank + addDice;
+            itemObj.total = statRank + specRank + addDice;
             itemData.data = itemObj;
         }
         this.actor.updateEmbeddedDocuments("Item", [itemData])

--- a/scripts/system/build-roll.js
+++ b/scripts/system/build-roll.js
@@ -1,7 +1,7 @@
 export default function buildRoll(data, rollData) {
     let buildRollData = rollData
 
-    // rollData arguement comes in with the following information
+    // rollData argument comes in with the following information
     /***
     *   rollData = {
     *       type: 
@@ -55,11 +55,7 @@ export default function buildRoll(data, rollData) {
 
     buildRollData.mind = mind;
 
-    if (rollData.type === "specialization") {
-        buildRollData.totalDice = rollData.specRank + rollData.skillRank + rollData.statRank + Number(rollData.addDice);
-    } else {
-        buildRollData.totalDice = rollData.specRank + rollData.skillRank + rollData.statRank + Number(rollData.addDice);
-    }
+    buildRollData.totalDice = rollData.statRank + Number(rollData.addDice) + (rollData.type === "specialization" ? rollData.specRank : rollData.skillRank);
     buildRollData.physicalDefense = pDefense
     return buildRollData;
 }

--- a/scripts/system/roll-card.js
+++ b/scripts/system/roll-card.js
@@ -39,7 +39,7 @@ export default function rollCard(rollResults, compiledRollData) {
 
     const flavorText = type === "stat" ? `Rolling <b>${compiledRollData.statName.toUpperCase()}</b><br>` :
         type === "skill" ? `Rolling <b>${compiledRollData.statName.toUpperCase()} & ${compiledRollData.skillName.toUpperCase()}</b><br>` :
-            type === "specialization" ? `Rolling <b>${compiledRollData.statName.toUpperCase()} & ${compiledRollData.skillName.toUpperCase()} & ${compiledRollData.specName.toUpperCase()}</b><br>` : `BOOPs!`;
+            type === "specialization" ? `Rolling <b>${compiledRollData.statName.toUpperCase()} & ${compiledRollData.specName.toUpperCase()}</b><br>` : `BOOPs!`;
 
     if (rollResults.type == "PoolTerm") {
         for (let d = 0; d < rollResults.terms[0].rolls[0].terms[0].results.length; d++) {

--- a/templates/sheet/partial/player-skills.html
+++ b/templates/sheet/partial/player-skills.html
@@ -97,9 +97,6 @@
                 <div class="spec-col-20 spec-table-col">
                     <span>General Skill</span>
                 </div>
-                <div class="spec-table-col spec-values">
-                    <span>Rank</span>
-                </div>
                 <div class="spec-col-20 spec-table-col">
                     <span>Stat</span>
                 </div>
@@ -129,10 +126,6 @@
                         <div class="spec-table-col spec-col-20">
                             <input type="text" value="{{spec.data.skill}}" readonly="readonly" />
                             <!--Linked Skill Name-->
-                        </div>
-                        <div class="spec-table-col spec-values">
-                            <input type="number" value="{{spec.data.skillRank}}" readonly="readonly" />
-                            <!--Linked Skill Rank-->
                         </div>
                         <div class="spec-table-col spec-col-20">
                             <input type="text" value="{{spec.data.statName}}" readonly="readonly" />

--- a/templates/sheet/partial/player-summary.html
+++ b/templates/sheet/partial/player-summary.html
@@ -93,9 +93,6 @@
                 <div class="spec-col-20 spec-table-col">
                     <span>General Skill</span>
                 </div>
-                <div class="spec-table-col spec-values">
-                    <span>Rank</span>
-                </div>
                 <div class="spec-col-20 spec-table-col">
                     <span>Stat</span>
                 </div>
@@ -132,12 +129,6 @@
                                 {{{spec.data.skill}}}
                             </span>
                             <!--Linked Skill Name-->
-                        </div>
-                        <div class="spec-table-col spec-values col-rank">
-                            <span>
-                                {{{spec.data.skillRank}}}
-                            </span>
-                            <!--Linked Skill Rank-->
                         </div>
                         <div class="spec-table-col spec-col-20">
                             <span>


### PR DESCRIPTION
#2 code fixes; in addition to the actual math fix, I've removed the base skill rank from the skill specialization tables so it's clear what's contributing. I kept the _name_ of the base skill so it's clear that say Physics is a specialization of Science.