### PR TITLE
[#27] Fix issues with `Item#system#relStat`

### DIFF
--- a/module/select-config.js
+++ b/module/select-config.js
@@ -45,17 +45,16 @@ COYOTE.primaryAction = {
 }
 
 COYOTE.stats = {
-    "select": "COYOTE.Stats.select",
-    "Agility": "COYOTE.Stats.Agility",
-    "Charisma": "COYOTE.Stats.Charisma",
-    "Endurance": "COYOTE.Stats.Endurance",
-    "Intelligence": "COYOTE.Stats.Intelligence",
-    "Perception": "COYOTE.Stats.Perception",
-    "Spirit": "COYOTE.Stats.Spirit",
-    "Strength": "COYOTE.Stats.Strength",
-    "Will": "COYOTE.Stats.Will",
-    "Wisdom": "COYOTE.Stats.Wisdom",
-    "Wealth": "COYOTE.Stats.Wealth"
+    "agility": "COYOTE.Stats.Agility",
+    "charisma": "COYOTE.Stats.Charisma",
+    "endurance": "COYOTE.Stats.Endurance",
+    "intelligence": "COYOTE.Stats.Intelligence",
+    "perception": "COYOTE.Stats.Perception",
+    "spirit": "COYOTE.Stats.Spirit",
+    "strength": "COYOTE.Stats.Strength",
+    "will": "COYOTE.Stats.Will",
+    "wisdom": "COYOTE.Stats.Wisdom",
+    "wealth": "COYOTE.Stats.Wealth"
 }
 
 COYOTE.dropdownSkills = {

--- a/scripts/actor/sheet/actor-sheet.js
+++ b/scripts/actor/sheet/actor-sheet.js
@@ -154,8 +154,8 @@ export class cncActorSheet extends foundry.appv1.sheets.ActorSheet {
                 name: game.i18n.format("ITEM.itemNew", { type: game.i18n.localize(`ITEM.ItemType${type.capitalize()}`) }),
                 type: type,
                 system: {
-                    relstat: relstat,
-                    ...foundry.utils.deepClone(header.dataset)
+                    ...foundry.utils.deepClone(header.dataset),
+                    relStat: relstat,
                 }
 
             };
@@ -219,7 +219,7 @@ export class cncActorSheet extends foundry.appv1.sheets.ActorSheet {
     *           In roll modifier screen - see current roll - decide to modify any dice by the relevant meta values
     *       Else roll normally
     *   \/
-    *   Send Results into roll card 
+    *   Send Results into roll card
     */
 
     async _diceRoll(event) {
@@ -252,7 +252,7 @@ export class cncActorSheet extends foundry.appv1.sheets.ActorSheet {
             return;
         }
 
-        // Send data and roll info to gather all information required for rolls. 
+        // Send data and roll info to gather all information required for rolls.
         const compiledRollData = buildRoll(data, rollData);
 
         const rollResults = await getRoll(compiledRollData)

--- a/scripts/items/item.js
+++ b/scripts/items/item.js
@@ -1,18 +1,8 @@
 //import { convertBurdenToGift } from "../system/utility.js";
 
 export class cncItem extends Item {
-    prepareData() {
-        super.prepareData();
-    }
-
-    _preCreate(data) {
-    }
-
-    prepareBaseData() {
- 
-    }
-
-    prepareDerivedData(data) {
+    prepareDerivedData() {
+      super.prepareDerivedData();
         //const itemData = this.data;
 
 
@@ -35,5 +25,19 @@ export class cncItem extends Item {
 
             this.system.activationName = activationName;
         }
+    }
+
+    /** @inheritdoc */
+    static migrateData(source) {
+      // Some items have system.relstat instead of system.relStat.
+      if (foundry.utils.hasProperty(source, "system.relstat")) {
+        if (!foundry.utils.hasProperty(source, "system.relStat")) source.system.relStat = source.system.relstat;
+        delete source.system.relstat;
+      }
+
+      // Some items were created with capitalized system.relStat value.
+      if (source.system?.relStat) source.system.relStat = source.system.relStat.toLowerCase();
+
+      return super.migrateData(source);
     }
 }

--- a/scripts/items/sheet/item-sheet.js
+++ b/scripts/items/sheet/item-sheet.js
@@ -26,14 +26,14 @@ export class cncItemSheet extends foundry.appv1.sheets.ItemSheet {
         let type = this.item.type;
         return `systems/coyote-and-crow/templates/sheet/${type}-sheet.html`;
     }
- 
+
     get itemData() {
         return this.item.data;
     }
 
     async getData(options) {
         const itemData = super.getData(options);
-        itemData.system = itemData.item._source.system;
+        itemData.system = itemData.item.toObject().system;
         itemData._id = itemData.data._id;
         itemData.system.dropDowns = CONFIG.COYOTE;
         console.log(itemData);

--- a/templates/sheet/ability-sheet.html
+++ b/templates/sheet/ability-sheet.html
@@ -10,12 +10,12 @@
         <label for="">Stat:</label>
         {{#if system.owned}}
         <select name="system.relStat">
-            {{selectOptions system.allowStats selected=system.relStat localize=true}}
+            {{selectOptions system.allowStats selected=system.relStat localize=true blank="COYOTE.Stats.select"}}
         </select>
 
         {{else}}
         <select name="system.relStat" value="{{system.relStat}}">
-            {{selectOptions system.dropDowns.stats selected=system.relStat localize=true}}
+            {{selectOptions system.dropDowns.stats selected=system.relStat localize=true blank="COYOTE.Stats.select"}}
         </select>
         {{/if}}
     </div>


### PR DESCRIPTION
Fix values in `system.relStats` select on unowned item sheets; mgrate existing data; remove "select" blank value.

The item sheet was also mutating the source data of the item. This was fixed by using `toObject` over  `_source`.

Closes #27.